### PR TITLE
Added MIN_PERL_VERSION to improve Kwalitee scores

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,4 +28,5 @@ WriteMakefile(
             },
         },
     })),
+	($mm_ver < 6.48 ? () : (MIN_PERL_VERSION => 5.006)),
 );


### PR DESCRIPTION
http://cpants.cpanauthors.org/dist/List-Compare suggests the addition of MIN_PERL_VERSION
Perl::MinimumVersion was used to determine 5.6 as the minimum required version for
all distribution modules.
