### PR TITLE
Added "use warnings" to improve Kwalitee scores

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,7 @@
 use ExtUtils::MakeMaker;
 require 5.006;
+use strict;
+use warnings;
 
 my $mm_ver = ExtUtils::MakeMaker->VERSION;
 

--- a/lib/List/Compare.pm
+++ b/lib/List/Compare.pm
@@ -1,7 +1,7 @@
 package List::Compare;
 $VERSION = '0.52';
 use strict;
-local $^W = 1;
+use warnings;
 use Carp;
 use List::Compare::Base::_Auxiliary qw(
     _validate_2_seenhashes

--- a/lib/List/Compare/Base/_Auxiliary.pm
+++ b/lib/List/Compare/Base/_Auxiliary.pm
@@ -67,7 +67,7 @@ use Carp;
     ) ],
 );
 use strict;
-local $^W =1;
+use warnings;
 
 my $bad_lists_msg = q{If argument is single hash ref, you must have a 'lists' key whose value is an array ref};
 

--- a/lib/List/Compare/Base/_Engine.pm
+++ b/lib/List/Compare/Base/_Engine.pm
@@ -14,7 +14,7 @@ use List::Compare::Base::_Auxiliary qw(
     _complement_all_engine
 |;
 use strict;
-local $^W = 1;
+use warnings;
 
 sub _unique_all_engine {
     my $aref = shift;

--- a/lib/List/Compare/Functional.pm
+++ b/lib/List/Compare/Functional.pm
@@ -91,7 +91,7 @@ $VERSION = 0.52;
     ) ],
 );
 use strict;
-local $^W = 1;
+use warnings;
 use Carp;
 use List::Compare::Base::_Auxiliary qw(
     _subset_subengine

--- a/t/IO/CaptureOutput.pm
+++ b/t/IO/CaptureOutput.pm
@@ -122,7 +122,7 @@ sub DESTROY {
         # some versions of perl complain about reading from fd 1 or 2
         # which could happen if STDOUT and STDERR were closed when $newio
         # was opened, so we just squelch warnings here and continue
-        local $^W; 
+        no warnings; 
         seek $newio, 0, 0;
         $$capture = do {local $/; <$newio>};
         close $newio;


### PR DESCRIPTION
http://cpants.cpanauthors.org/dist/List-Compare suggests the use of warnings.
Replaced usage of $^W by use/no warnings.
