### PR TITLE
Allow -u|--unsorted and -a|--accelerated in any order in new()

### DIFF
--- a/lib/List/Compare.pm
+++ b/lib/List/Compare.pm
@@ -6,6 +6,7 @@ use Carp;
 use List::Compare::Base::_Auxiliary qw(
     _validate_2_seenhashes
     _chart_engine_regular
+	_parse_options
 );
 
 sub new {
@@ -24,10 +25,7 @@ sub new {
         $accelerated = ${$argref}{'accelerated'} ? 1 : '';
     } else {
         @args = @_;
-        $unsorted = ($args[0] eq '-u' or $args[0] eq '--unsorted')
-            ? shift(@args) : '';
-        $accelerated = shift(@args)
-            if ($args[0] eq '-a' or $args[0] eq '--accelerated');
+		($unsorted, $accelerated) = _parse_options(\@args);
     }
     $argument_error_status = 1;
     @testargs = @args[1..$#args];
@@ -2821,9 +2819,10 @@ any references to lists are passed to the constructor.
 
 Note that if are calling List::Compare in the Accelerated or Multiple
 Accelerated mode I<and> wish to have the lists returned in unsorted order,
-you I<first> pass the argument for the unsorted option
-(C<'-u'> or C<'--unsorted'>) and I<then> pass the argument for the
-Accelerated mode (C<'-a'> or C<'--accelerated'>).
+you can pass the argument for the unsorted option
+(C<'-u'> or C<'--unsorted'>) and the argument for the
+Accelerated mode (C<'-a'> or C<'--accelerated'>) in any order,
+as long as they appear before the actual lists to be compared.
 
 =back
 

--- a/lib/List/Compare/Base/_Auxiliary.pm
+++ b/lib/List/Compare/Base/_Auxiliary.pm
@@ -38,6 +38,7 @@ use Carp;
     _alt_construct_tester_3
     _alt_construct_tester_4
     _alt_construct_tester_5
+	_parse_options
 |;
 %EXPORT_TAGS = (
     calculate => [ qw(
@@ -64,6 +65,7 @@ use Carp;
         _alt_construct_tester_3
         _alt_construct_tester_4
         _alt_construct_tester_5
+		_parse_options
     ) ],
 );
 use strict;
@@ -596,8 +598,7 @@ sub _alt_construct_tester {
        $argref = ${$hashref}{'lists'};
        $unsorted = ${$hashref}{'unsorted'} ? 1 : '';
     } else {
-        $unsorted = shift(@args)
-            if ($args[0] eq '-u' or $args[0] eq '--unsorted');
+        ($unsorted) = _parse_options(\@args);
         $argref = shift(@args);
     }
     return ($argref, $unsorted);
@@ -659,7 +660,7 @@ sub _alt_construct_tester_3 {
         $argref = \@returns;
         $unsorted = ${$hashref}{'unsorted'} ? 1 : '';
     } else {
-        $unsorted = shift(@args) if ($args[0] eq '-u' or $args[0] eq '--unsorted');
+        ($unsorted) = _parse_options(\@args);
         $argref = \@args;
     }
     return ($argref, $unsorted);
@@ -705,6 +706,32 @@ sub _alt_construct_tester_5 {
         croak "Subroutine call requires exactly 1 reference as argument:  $!";
     }
     return $argref;
+}
+
+# ($unsorted, $accelerated) = _parse_options( \@args );
+# input: reference to list of arguments passed in to a function
+# output:
+# - $unsorted    set if '-u' or '--unsorted'    as one of the first list elements
+# - $accelerated set if '-a' or '--accelerated' as one of the first list elements
+# the options, if found, are removed from the passed in list
+# the options can be passed in any order
+sub _parse_options {
+	my($args) = @_;
+	croak "Need to be passed a reference to a list"
+		unless ref($args) eq 'ARRAY';
+	my($unsorted, $accelerated) = ('', '');
+	while (@$args && !ref($args->[0])) {
+		if ($args->[0] eq '-u' || $args->[0] eq '--unsorted') {
+			$unsorted = shift @$args;
+		}
+		elsif ($args->[0] eq '-a' || $args->[0] eq '--accelerated') {
+			$accelerated = shift @$args;
+		}
+		else {
+			last;
+		}
+	}
+	return ($unsorted, $accelerated);
 }
 
 1;

--- a/t/04_oo_lists_dual_acc_unsorted.t
+++ b/t/04_oo_lists_dual_acc_unsorted.t
@@ -452,20 +452,20 @@ for my $opt1 ('', qw| -u --unsorted |) {
 							 }
 						   ]
 						  ) {							   
-			my $lc = List::Compare->new(@$args);
-			ok($lc, "Constructor worked with '@opts' options");
-			my @intersection = qw| golfer delta edward baker camera fargo  |;
-			@intersection = sort @intersection unless $unsorted;
-			if ($accelerated) {
-				ok(! $lc->{'intersection'}, "Results not pre-computed");
-			}
-			else {
-				is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-			}
-			is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
-			if ($accelerated) {
-				ok(! $lc->{'intersection'}, "Results not stored");
-			}
+				my $lc = List::Compare->new(@$args);
+				ok($lc, "Constructor worked with '@opts' options");
+				my @intersection = qw| golfer delta edward baker camera fargo  |;
+				@intersection = sort @intersection unless $unsorted;
+				if ($accelerated) {
+					ok(! $lc->{'intersection'}, "Results not pre-computed");
+				}
+				else {
+					is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+				}
+				is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+				if ($accelerated) {
+					ok(! $lc->{'intersection'}, "Results not stored");
+				}
 			}
 		}
 	}

--- a/t/04_oo_lists_dual_acc_unsorted.t
+++ b/t/04_oo_lists_dual_acc_unsorted.t
@@ -2,7 +2,7 @@
 #$Id$
 # 04_oo_lists_dual_acc_unsorted.t
 use strict;
-use Test::More tests => 170;
+use Test::More tests => 151;
 use List::Compare;
 use lib ("./t");
 use Test::ListCompareSpecial qw( :seen :wrap :arrays :results );
@@ -436,35 +436,41 @@ $disj = $lcu_dj->is_LdisjointR;
 ok($disj, "disjoint correctly determined");
 
 ########## Tests for '--unsorted' and '--accelerated' in any order ##########
+# - test depends on white-box knowledge of module internals, to check if
+#   --accelerated is working as expected
+# - test depends on the order of keys %array, which is assumed to be the same
+#   in the same perl interpreter, to check if --unsorted is working as expected
+
+# set up test data
+my %expected_intersection;
+foreach (qw| golfer delta edward baker camera fargo  |) {
+    $expected_intersection{$_}++;
+}
+my @unsorted_intersection =      keys %expected_intersection;
+my @sorted_intersection   = sort keys %expected_intersection;
 
 ########## Options: <empty>
 
 # list-arguments to constructor
 my $lc = List::Compare->new(\@a0, \@a1);
-ok($lc, "Constructor worked with '' options");
-my @intersection = sort qw| golfer delta edward baker camera fargo  |;
-is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->{'intersection'}, \@sorted_intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@sorted_intersection, "Results ok");
 
 # hash-arguments to constructor
 my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
 							   accelerated => 0,
 							   unsorted    => 0,
 							 });
-ok($lc, "Constructor worked with '' options");
-my @intersection = sort qw| golfer delta edward baker camera fargo  |;
-is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->{'intersection'}, \@sorted_intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@sorted_intersection, "Results ok");
 
 
 ########## Options: --accelerated
 
 # list-arguments to constructor
 my $lc = List::Compare->new('--accelerated', \@a0, \@a1);
-ok($lc, "Constructor worked with '--accelerated' options");
-my @intersection = sort qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@sorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 # hash-arguments to constructor
@@ -472,10 +478,8 @@ my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
 							   accelerated => 1,
 							   unsorted    => 0,
 							 });
-ok($lc, "Constructor worked with '--accelerated' options");
-my @intersection = sort qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@sorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
@@ -483,10 +487,8 @@ ok(! $lc->{'intersection'}, "Results not stored");
 
 # list-arguments to constructor
 my $lc = List::Compare->new('-a', \@a0, \@a1);
-ok($lc, "Constructor worked with '-a' options");
-my @intersection = sort qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@sorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 # hash-arguments to constructor
@@ -494,10 +496,8 @@ my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
 							   accelerated => 1,
 							   unsorted    => 0,
 							 });
-ok($lc, "Constructor worked with '-a' options");
-my @intersection = sort qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@sorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
@@ -505,50 +505,40 @@ ok(! $lc->{'intersection'}, "Results not stored");
 
 # list-arguments to constructor
 my $lc = List::Compare->new('--unsorted', \@a0, \@a1);
-ok($lc, "Constructor worked with '--unsorted' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
-is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->{'intersection'}, \@unsorted_intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 
 # hash-arguments to constructor
 my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
 							   accelerated => 0,
 							   unsorted    => 1,
 							 });
-ok($lc, "Constructor worked with '--unsorted' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
-is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->{'intersection'}, \@unsorted_intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 
 
 ########## Options: -u
 
 # list-arguments to constructor
 my $lc = List::Compare->new('-u', \@a0, \@a1);
-ok($lc, "Constructor worked with '-u' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
-is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->{'intersection'}, \@unsorted_intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 
 # hash-arguments to constructor
 my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
 							   accelerated => 0,
 							   unsorted    => 1,
 							 });
-ok($lc, "Constructor worked with '-u' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
-is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->{'intersection'}, \@unsorted_intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 
 
 ########## Options: --accelerated --unsorted
 
 # list-arguments to constructor
 my $lc = List::Compare->new('--accelerated', '--unsorted', \@a0, \@a1);
-ok($lc, "Constructor worked with '--accelerated --unsorted' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 # hash-arguments to constructor
@@ -556,79 +546,63 @@ my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
 							   accelerated => 1,
 							   unsorted    => 1,
 							 });
-ok($lc, "Constructor worked with '--accelerated --unsorted' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
 ########## Options: --accelerated -u
 
 my $lc = List::Compare->new('--accelerated', '-u', \@a0, \@a1);
-ok($lc, "Constructor worked with '--accelerated -u' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
 ########## Options: --unsorted --accelerated
 
 my $lc = List::Compare->new('--unsorted', '--accelerated', \@a0, \@a1);
-ok($lc, "Constructor worked with '--unsorted --accelerated' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
 ########## Options: --unsorted -a
 
 my $lc = List::Compare->new('--unsorted', '-a', \@a0, \@a1);
-ok($lc, "Constructor worked with '--unsorted -a' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
 ########## Options: -a --unsorted
 
 my $lc = List::Compare->new('-a', '--unsorted', \@a0, \@a1);
-ok($lc, "Constructor worked with '-a --unsorted' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
 ########## Options: -a -u
 
 my $lc = List::Compare->new('-a', '-u', \@a0, \@a1);
-ok($lc, "Constructor worked with '-a -u' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
 ########## Options: -u --accelerated
 
 my $lc = List::Compare->new('-u', '--accelerated', \@a0, \@a1);
-ok($lc, "Constructor worked with '-u --accelerated' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 
 
 ########## Options: -u -a
 
 my $lc = List::Compare->new('-u', '-a', \@a0, \@a1);
-ok($lc, "Constructor worked with '-u -a' options");
-my @intersection = qw| golfer delta edward baker camera fargo  |;
 ok(! $lc->{'intersection'}, "Results not pre-computed");
-is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+is_deeply($lc->get_intersection_ref, \@unsorted_intersection, "Results ok");
 ok(! $lc->{'intersection'}, "Results not stored");
 

--- a/t/04_oo_lists_dual_acc_unsorted.t
+++ b/t/04_oo_lists_dual_acc_unsorted.t
@@ -2,7 +2,7 @@
 #$Id$
 # 04_oo_lists_dual_acc_unsorted.t
 use strict;
-use Test::More tests => 232;
+use Test::More tests => 170;
 use List::Compare;
 use lib ("./t");
 use Test::ListCompareSpecial qw( :seen :wrap :arrays :results );
@@ -435,38 +435,200 @@ ok(0 == scalar(@{$lcu_dj->get_intersection_ref}),
 $disj = $lcu_dj->is_LdisjointR;
 ok($disj, "disjoint correctly determined");
 
-########## BELOW:  Tests for '--unsorted' and '--accelerated' options ##########
-for my $opt1 ('', qw| -u --unsorted |) {
-	my $unsorted = $opt1;
-	for my $opt2 ('', qw| -a --accelerated |) {
-		my $accelerated = $opt2;
-		for my $swap (0..1) {
-			my @opts = grep {$_} ($opt1, $opt2);
-			@opts = reverse @opts if $swap;
-			for my $args ( # list-arguments to constructor
-						   [ @opts, \@a0, \@a1 ],
-						   # hash-arguments to constructor
-						   [ { lists       => [ \@a0, \@a1 ],
-						       accelerated => $accelerated,
-							   unsorted    => $unsorted,
-							 }
-						   ]
-						  ) {							   
-				my $lc = List::Compare->new(@$args);
-				ok($lc, "Constructor worked with '@opts' options");
-				my @intersection = qw| golfer delta edward baker camera fargo  |;
-				@intersection = sort @intersection unless $unsorted;
-				if ($accelerated) {
-					ok(! $lc->{'intersection'}, "Results not pre-computed");
-				}
-				else {
-					is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
-				}
-				is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
-				if ($accelerated) {
-					ok(! $lc->{'intersection'}, "Results not stored");
-				}
-			}
-		}
-	}
-}
+########## Tests for '--unsorted' and '--accelerated' in any order ##########
+
+########## Options: <empty>
+
+# list-arguments to constructor
+my $lc = List::Compare->new(\@a0, \@a1);
+ok($lc, "Constructor worked with '' options");
+my @intersection = sort qw| golfer delta edward baker camera fargo  |;
+is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+
+# hash-arguments to constructor
+my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
+							   accelerated => 0,
+							   unsorted    => 0,
+							 });
+ok($lc, "Constructor worked with '' options");
+my @intersection = sort qw| golfer delta edward baker camera fargo  |;
+is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+
+
+########## Options: --accelerated
+
+# list-arguments to constructor
+my $lc = List::Compare->new('--accelerated', \@a0, \@a1);
+ok($lc, "Constructor worked with '--accelerated' options");
+my @intersection = sort qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+# hash-arguments to constructor
+my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
+							   accelerated => 1,
+							   unsorted    => 0,
+							 });
+ok($lc, "Constructor worked with '--accelerated' options");
+my @intersection = sort qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: -a
+
+# list-arguments to constructor
+my $lc = List::Compare->new('-a', \@a0, \@a1);
+ok($lc, "Constructor worked with '-a' options");
+my @intersection = sort qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+# hash-arguments to constructor
+my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
+							   accelerated => 1,
+							   unsorted    => 0,
+							 });
+ok($lc, "Constructor worked with '-a' options");
+my @intersection = sort qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: --unsorted
+
+# list-arguments to constructor
+my $lc = List::Compare->new('--unsorted', \@a0, \@a1);
+ok($lc, "Constructor worked with '--unsorted' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+
+# hash-arguments to constructor
+my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
+							   accelerated => 0,
+							   unsorted    => 1,
+							 });
+ok($lc, "Constructor worked with '--unsorted' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+
+
+########## Options: -u
+
+# list-arguments to constructor
+my $lc = List::Compare->new('-u', \@a0, \@a1);
+ok($lc, "Constructor worked with '-u' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+
+# hash-arguments to constructor
+my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
+							   accelerated => 0,
+							   unsorted    => 1,
+							 });
+ok($lc, "Constructor worked with '-u' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+
+
+########## Options: --accelerated --unsorted
+
+# list-arguments to constructor
+my $lc = List::Compare->new('--accelerated', '--unsorted', \@a0, \@a1);
+ok($lc, "Constructor worked with '--accelerated --unsorted' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+# hash-arguments to constructor
+my $lc = List::Compare->new({  lists       => [ \@a0, \@a1 ],
+							   accelerated => 1,
+							   unsorted    => 1,
+							 });
+ok($lc, "Constructor worked with '--accelerated --unsorted' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: --accelerated -u
+
+my $lc = List::Compare->new('--accelerated', '-u', \@a0, \@a1);
+ok($lc, "Constructor worked with '--accelerated -u' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: --unsorted --accelerated
+
+my $lc = List::Compare->new('--unsorted', '--accelerated', \@a0, \@a1);
+ok($lc, "Constructor worked with '--unsorted --accelerated' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: --unsorted -a
+
+my $lc = List::Compare->new('--unsorted', '-a', \@a0, \@a1);
+ok($lc, "Constructor worked with '--unsorted -a' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: -a --unsorted
+
+my $lc = List::Compare->new('-a', '--unsorted', \@a0, \@a1);
+ok($lc, "Constructor worked with '-a --unsorted' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: -a -u
+
+my $lc = List::Compare->new('-a', '-u', \@a0, \@a1);
+ok($lc, "Constructor worked with '-a -u' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: -u --accelerated
+
+my $lc = List::Compare->new('-u', '--accelerated', \@a0, \@a1);
+ok($lc, "Constructor worked with '-u --accelerated' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+
+
+########## Options: -u -a
+
+my $lc = List::Compare->new('-u', '-a', \@a0, \@a1);
+ok($lc, "Constructor worked with '-u -a' options");
+my @intersection = qw| golfer delta edward baker camera fargo  |;
+ok(! $lc->{'intersection'}, "Results not pre-computed");
+is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+ok(! $lc->{'intersection'}, "Results not stored");
+

--- a/t/04_oo_lists_dual_acc_unsorted.t
+++ b/t/04_oo_lists_dual_acc_unsorted.t
@@ -2,7 +2,7 @@
 #$Id$
 # 04_oo_lists_dual_acc_unsorted.t
 use strict;
-use Test::More tests => 166;
+use Test::More tests => 232;
 use List::Compare;
 use lib ("./t");
 use Test::ListCompareSpecial qw( :seen :wrap :arrays :results );
@@ -443,7 +443,16 @@ for my $opt1 ('', qw| -u --unsorted |) {
 		for my $swap (0..1) {
 			my @opts = grep {$_} ($opt1, $opt2);
 			@opts = reverse @opts if $swap;
-			my $lc = List::Compare->new(@opts, \@a0, \@a1);
+			for my $args ( # list-arguments to constructor
+						   [ @opts, \@a0, \@a1 ],
+						   # hash-arguments to constructor
+						   [ { lists       => [ \@a0, \@a1 ],
+						       accelerated => $accelerated,
+							   unsorted    => $unsorted,
+							 }
+						   ]
+						  ) {							   
+			my $lc = List::Compare->new(@$args);
 			ok($lc, "Constructor worked with '@opts' options");
 			my @intersection = qw| golfer delta edward baker camera fargo  |;
 			@intersection = sort @intersection unless $unsorted;
@@ -456,6 +465,7 @@ for my $opt1 ('', qw| -u --unsorted |) {
 			is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
 			if ($accelerated) {
 				ok(! $lc->{'intersection'}, "Results not stored");
+			}
 			}
 		}
 	}

--- a/t/04_oo_lists_dual_acc_unsorted.t
+++ b/t/04_oo_lists_dual_acc_unsorted.t
@@ -2,7 +2,7 @@
 #$Id$
 # 04_oo_lists_dual_acc_unsorted.t
 use strict;
-use Test::More tests => 109;
+use Test::More tests => 166;
 use List::Compare;
 use lib ("./t");
 use Test::ListCompareSpecial qw( :seen :wrap :arrays :results );
@@ -436,31 +436,27 @@ $disj = $lcu_dj->is_LdisjointR;
 ok($disj, "disjoint correctly determined");
 
 ########## BELOW:  Tests for '--unsorted' and '--accelerated' options ##########
-
-my $lcaun   = List::Compare->new('--unsorted', '-a', \@a0, \@a1);
-ok($lcaun, "Constructor worked with --unsorted and -a options");
-
-my $lcaun_s  = List::Compare->new('--unsorted', '-a', \@a2, \@a3);
-ok($lcaun_s, "Constructor worked with --unsorted and -a options");
-
-my $lcaun_e  = List::Compare->new('--unsorted', '-a', \@a3, \@a4);
-ok($lcaun_e, "Constructor worked with --unsorted and -a options");
-
-my $lcaccun   = List::Compare->new('--unsorted', '--accelerated', \@a0, \@a1);
-ok($lcaccun, "Constructor worked with --unsorted and --accelerated options");
-
-my $lcaccun_s  = List::Compare->new('--unsorted', '--accelerated', \@a2, \@a3);
-ok($lcaccun_s, "Constructor worked with --unsorted and --accelerated options");
-
-my $lcaccun_e  = List::Compare->new('--unsorted', '--accelerated', \@a3, \@a4);
-ok($lcaccun_e, "Constructor worked with --unsorted and --accelerated options");
-
-my $lcaccu   = List::Compare->new('-u', '--accelerated', \@a0, \@a1);
-ok($lcaccu, "Constructor worked with -u and --accelerated options");
-
-my $lcaccu_s  = List::Compare->new('-u', '--accelerated', \@a2, \@a3);
-ok($lcaccu_s, "Constructor worked with -u and --accelerated options");
-
-my $lcaccu_e  = List::Compare->new('-u', '--accelerated', \@a3, \@a4);
-ok($lcaccu_e, "Constructor worked with -u and --accelerated options");
-
+for my $opt1 ('', qw| -u --unsorted |) {
+	my $unsorted = $opt1;
+	for my $opt2 ('', qw| -a --accelerated |) {
+		my $accelerated = $opt2;
+		for my $swap (0..1) {
+			my @opts = grep {$_} ($opt1, $opt2);
+			@opts = reverse @opts if $swap;
+			my $lc = List::Compare->new(@opts, \@a0, \@a1);
+			ok($lc, "Constructor worked with '@opts' options");
+			my @intersection = qw| golfer delta edward baker camera fargo  |;
+			@intersection = sort @intersection unless $unsorted;
+			if ($accelerated) {
+				ok(! $lc->{'intersection'}, "Results not pre-computed");
+			}
+			else {
+				is_deeply($lc->{'intersection'}, \@intersection, "Results pre-computed");
+			}
+			is_deeply($lc->get_intersection_ref, \@intersection, "Results ok");
+			if ($accelerated) {
+				ok(! $lc->{'intersection'}, "Results not stored");
+			}
+		}
+	}
+}


### PR DESCRIPTION
The code for List::Compare::new() only detected correctly the unsorted and
accelerated options if they were given in this exact order.

This not-intuitive behavior was described in a documentation note in the POD.

Moreover the code to detect -u|--unsorted was repeated in three locations:
List::Compare::new(), List::Compare::Base::_Auxiliary::_alt_construct_tester() and
List::Compare::Base::_Auxiliary::_alt_construct_tester_3().

Factored the code to detect -u|--unsorted and/or -a|--accelerated in any order in
List::Compare::Base::_Auxiliary::_parse_optios(), and called this new function from the
three places where the parsing was being done.

Changed t/04_oo_lists_dual_acc_unsorted.t to try all possible combinations of short/long
options, in any order, with presence/absence of each option and check the result of the
object construction to make sure the options were being take into account.

Removed the restriction of the options mandatory order from the POD.
